### PR TITLE
feat: add git status decorator settings (#6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 lib
+node_modules

--- a/package.json
+++ b/package.json
@@ -63,6 +63,26 @@
           "default": "",
           "description": "Branch character used with g:coc_git_branch"
         },
+        "git.changedDecorator": {
+          "type": "string",
+          "default": "*",
+          "description": "Git changed decorator used with g:coc_git_branch"
+        },
+        "git.conflictedDecorator": {
+          "type": "string",
+          "default": "x",
+          "description": "Git conflicted decorator used with g:coc_git_branch"
+        },
+        "git.stagedDecorator": {
+          "type": "string",
+          "default": "●",
+          "description": "Git staged decorator used with g:coc_git_branch"
+        },
+        "git.untrackedDecorator": {
+          "type": "string",
+          "default": "…",
+          "description": "Git untracked decorator used with g:coc_git_branch"
+        },
         "git.enableGutters": {
           "type": "boolean",
           "default": true,

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -67,7 +67,16 @@ export default class DocumentManager {
     if (!root) {
       nvim.setVar('coc_git_status', '', true)
     } else {
-      let status = await gitStatus(root, character)
+      const changedDecorator = this.config.get<string>('changedDecorator', '*')
+      const conflictedDecorator = this.config.get<string>('conflictedDecorator', 'x')
+      const stagedDecorator = this.config.get<string>('stagedDecorator', '●')
+      const untrackedDecorator = this.config.get<string>('untrackedDecorator', '…')
+      let status = await gitStatus(root, character, {
+        changedDecorator,
+        conflictedDecorator,
+        stagedDecorator,
+        untrackedDecorator,
+      })
       if (workspace.bufnr != bufnr) return
       nvim.setVar('coc_git_status', status, true)
     }

--- a/src/status.ts
+++ b/src/status.ts
@@ -45,14 +45,22 @@ async function gitUntracked(cwd: string): Promise<number> {
   return out.split('\n').length
 }
 
-export async function gitStatus(cwd: string, character: string): Promise<string> {
+interface Decorator {
+  changedDecorator: string
+  conflictedDecorator: string
+  stagedDecorator: string
+  untrackedDecorator: string
+}
+
+export async function gitStatus(cwd: string, character: string, decorator: Decorator): Promise<string> {
   let res = await Promise.all([gitBranch(cwd), gitChanged(cwd), gitStaged(cwd), gitUntracked(cwd)])
   if (!res[0]) return ''
   let [branch, changed, staged, untracked] = res
   let more = ''
-  if (changed) more += '+'
-  if (staged[0]) more += 'x'
-  if (staged[1]) more += '●'
-  if (untracked) more += '…'
-  return `  ${character ? character + ' ' : ''}${branch}${more == '' ? ' ' : ' ' + more + ' '}`
+  const { changedDecorator, conflictedDecorator, stagedDecorator, untrackedDecorator } = decorator
+  if (changed) more += changedDecorator
+  if (staged[0]) more += conflictedDecorator
+  if (staged[1]) more += stagedDecorator
+  if (untracked) more += untrackedDecorator
+  return `  ${character ? character + ' ' : ''}${branch}${more == '' ? ' ' : more + ' '}`
 }


### PR DESCRIPTION
定制 ${branch}${decorator}
```json
{
        // ...
        "git.changedDecorator": {
          "type": "string",
          "default": "*",
          "description": "Git changed decorator used with g:coc_git_branch"
        },
        "git.conflictedDecorator": {
          "type": "string",
          "default": "x",
          "description": "Git conflicted decorator used with g:coc_git_branch"
        },
        "git.stagedDecorator": {
          "type": "string",
          "default": "●",
          "description": "Git staged decorator used with g:coc_git_branch"
        },
        "git.untrackedDecorator": {
          "type": "string",
          "default": "…",
          "description": "Git untracked decorator used with g:coc_git_branch"
        },
       // ...
}
```

Like VSCode master*