### PR TITLE
Add block support for git.browserOpen

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,6 +1,6 @@
 import { Uri, workspace } from 'coc.nvim'
 
-export function getUrl(remote: string, branch: string, filepath: string, line?: number): string {
+export function getUrl(remote: string, branch: string, filepath: string, lines?: number[]): string {
   let uri = remote.replace(/\.git$/, '')
   if (uri.startsWith('git')) {
     let str = uri.slice(4)
@@ -9,7 +9,8 @@ export function getUrl(remote: string, branch: string, filepath: string, line?: 
   }
   let u = Uri.parse(uri)
   if (u.authority.startsWith('github.com')) {
-    return uri + '/blob/' + branch + '/' + filepath + (line ? '#L' + line : '')
+    const anchor = lines ? lines.map(l => `L${l}`).join('-') : ''
+    return uri + '/blob/' + branch + '/' + filepath + (anchor ? '#' + anchor : '')
   }
   workspace.showMessage(`Can't get url form: ${u.authority}`)
   return ''

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -357,7 +357,13 @@ export default class DocumentManager {
       workspace.showMessage(`Failed on git symbolic-ref`, 'warning')
       return
     }
-    let line = await nvim.eval('line(".")') as number
+    const mode = await nvim.call('mode') as string
+
+    const lines = (mode.toLowerCase() === 'v') ? [
+      await nvim.eval(`line("'<")`) as number,
+      await nvim.eval(`line(">'")`) as number,
+    ] : [await nvim.eval('line(".")') as number]
+
     let fullpath = await nvim.eval('expand("%:p")') as string
     let relpath = path.relative(root, fullpath)
     let names = output.trim().split(/\r?\n/)
@@ -366,7 +372,7 @@ export default class DocumentManager {
       let uri = await safeRun(`git remote get-url ${name}`, { cwd: root })
       uri = uri.replace(/\s+$/, '')
       if (!uri.length) continue
-      let url = getUrl(uri, head, relpath, line)
+      let url = getUrl(uri, head, relpath, lines)
       if (url) urls.push(url)
     }
     if (urls.length == 1) {


### PR DESCRIPTION
Read the command range to open the github URL with the selected lines.

Depends on neoclide/coc.nvim#789