### PR TITLE
add escape for git command

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -75,7 +75,7 @@ export async function getDiff(root: string, doc: Document): Promise<Diff[]> {
   const currentFile = path.join(os.tmpdir(), `coc-${uuid()}`)
   let fsPath = Uri.parse(doc.uri).fsPath
   let file = path.relative(root, fsPath)
-  let res = await safeRun(`git --no-pager show :${file}`, { cwd: root })
+  let res = await safeRun(`git --no-pager show :"${file.replace(/\"/g, '\\"')}"`, { cwd: root })
   if (res == null) return null
   let staged = res.replace(/\r?\n$/, '').split(/\r?\n/).join('\n')
   await util.promisify(fs.writeFile)(stagedFile, staged + '\n', 'utf8')

--- a/src/lists/bcommits.ts
+++ b/src/lists/bcommits.ts
@@ -147,7 +147,7 @@ export default class Bcommits extends BasicList {
       return
     }
     let file = path.relative(root, Uri.parse(doc.uri).fsPath)
-    const output = await runCommand(`git ls-files ${context.args.join(' ')} -- ${file}`)
+    const output = await runCommand(`git ls-files ${context.args.join(' ')} -- "${file.replace(/\"/g, '\\"')}"`)
     if (!output.trim()) {
       throw new Error(`${file} not indexed`)
       return

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -474,7 +474,7 @@ export default class DocumentManager {
     }
     let fullpath = await nvim.eval('expand("%:p")') as string
     let relpath = path.relative(root, fullpath)
-    let res = await safeRun(`git ls-files -- ${relpath}`, { cwd: root })
+    let res = await safeRun(`git ls-files -- "${relpath.replace(/\"/g, '\\"')}"`, { cwd: root })
     if (!res.length) {
       workspace.showMessage(`"${relpath}" not indexed.`, 'warning')
       return


### PR DESCRIPTION
如果本地仓库的目录带有空格 `"` `$` 等，会导致 coc-git 的部分功能失效