### PR TITLE
fix: allow diffs for files starting with ".git"

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -75,7 +75,7 @@ export async function getDiff(root: string, doc: Document): Promise<Diff[]> {
   const currentFile = path.join(os.tmpdir(), `coc-${uuid()}`)
   let fsPath = Uri.parse(doc.uri).fsPath
   let file = path.relative(root, fsPath)
-  if (file.startsWith('.git')) return null
+  if (file.startsWith(`.git${path.sep}`)) return null
   let res = await safeRun(`git --no-pager show ${shellescape(':' + file)}`, { cwd: root })
   if (res == null) return null
   let staged = res.replace(/\r?\n$/, '').split(/\r?\n/).join('\n')


### PR DESCRIPTION
Currently files like `.gitignore` or `.gitlab-ci.yml` are ignored. Another solution would be to remove the check for `.git/`, then it would be treated like an untracked file (`return null`).