### PR TITLE
Fix/Delete folds on unfolding

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -196,6 +196,15 @@ export default class DocumentManager {
     let enabled = this.enabledFolds.has(bufnr)
     if (enabled) {
       this.enabledFolds.delete(bufnr)
+      let cursor = await nvim.commandOutput('echo getpos(".")') 
+      for (let i = 1; i <= doc.lineCount; i++) {
+        let foldend = Number(await nvim.commandOutput(`echo foldclosedend("${i}}")`))
+        if (foldend != -1) {
+          await nvim.command(`${foldend}normal! zd`)
+          i = foldend + 1
+        }
+      }
+      await nvim.command(`call setpos(".", ${cursor})`)
       let settings = this.foldSettingsMap.get(bufnr)
       nvim.pauseNotification()
       win.setOption('foldmethod', settings.foldmethod, true)

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -196,9 +196,9 @@ export default class DocumentManager {
     let enabled = this.enabledFolds.has(bufnr)
     if (enabled) {
       this.enabledFolds.delete(bufnr)
-      let cursor = await nvim.commandOutput('echo getpos(".")') 
+      let cursor = await nvim.eval('getpos(".")') 
       for (let i = 1; i <= doc.lineCount; i++) {
-        let foldend = Number(await nvim.commandOutput(`echo foldclosedend("${i}}")`))
+        let foldend = Number(await nvim.eval(`echo foldclosedend("${i}}")`))
         if (foldend != -1) {
           await nvim.command(`${foldend}normal! zd`)
           i = foldend + 1

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -198,7 +198,7 @@ export default class DocumentManager {
       this.enabledFolds.delete(bufnr)
       let cursor = await nvim.eval('getpos(".")') 
       for (let i = 1; i <= doc.lineCount; i++) {
-        let foldend = Number(await nvim.eval(`echo foldclosedend("${i}}")`))
+        let foldend = Number(await nvim.eval(`foldclosedend("${i}}")`))
         if (foldend != -1) {
           await nvim.command(`${foldend}normal! zd`)
           i = foldend + 1

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -204,7 +204,7 @@ export default class DocumentManager {
           i = foldend + 1
         }
       }
-      await nvim.command(`call setpos(".", ${cursor})`)
+      await nvim.call(`setpos(".", ${cursor})`)
       let settings = this.foldSettingsMap.get(bufnr)
       nvim.pauseNotification()
       win.setOption('foldmethod', settings.foldmethod, true)


### PR DESCRIPTION
When unfolding the created folds are not removed. This means when folding again any new changes are still folded over. This PR adds in a set of steps to delete the folds that were added.

There may well be a better way to do this but I'm not too sure on vimscript or typescript so this is what I can do. The only issue I see is that the cursor jumps briefly while deleting the folds.