### PR TITLE
Add missing attribute to the Issue interface definition

### DIFF
--- a/src/source.ts
+++ b/src/source.ts
@@ -11,6 +11,7 @@ interface Issue {
   creator: string
   body: string
   repo: string
+  url: string
 }
 
 const issuesMap: Map<number, Issue[]> = new Map()


### PR DESCRIPTION
Recently [this](https://github.com/neoclide/coc-git/blob/master/src/source.ts#L76) change was introduced but the `Issue` interface was not updated to support it.