### PR TITLE
feat: add git.chunkSelect

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -156,6 +156,7 @@ related commands.
 - `:CocCommand git.chunkInfo` Show chunk info under cursor.
 - `:CocCommand git.chunkUndo` Undo current chunk.
 - `:CocCommand git.chunkStage` Stage current chunk.
+- `:CocCommand git.chunkSelect` Select current chunk
 - `:CocCommand git.diffCached` Show cached diff in preview window.
 - `:CocCommand git.showCommit` Show commit of current chunk.
 - `:CocCommand git.browserOpen` Open current line in browser, github url supported.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "git"
   ],
   "engines": {
-    "coc": "^0.0.72"
+    "coc": "^0.0.73"
   },
   "repository": {
     "type": "git",
@@ -36,6 +36,10 @@
       {
         "title": "Undo current chunk.",
         "command": "git.chunkUndo"
+      },
+      {
+        "title": "Select current chunk.",
+        "command": "git.chunkSelect"
       },
       {
         "title": "Show commit of current chunk.",
@@ -245,7 +249,7 @@
     "@types/node": "^10.12.24",
     "@types/uuid": "^3.4.4",
     "@types/which": "^1.3.1",
-    "coc.nvim": "^0.0.71",
+    "coc.nvim": "^0.0.73",
     "colors": "^1.3.3",
     "debounce": "^1.2.0",
     "request-light": "^0.2.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,10 @@ export async function activate(context: ExtensionContext): Promise<void> {
     await manager.chunkUndo()
   }))
 
+  subscriptions.push(commands.registerCommand('git.chunkSelect', async ()=>{
+    await manager.chunkSelect()
+  }))
+
   subscriptions.push(commands.registerCommand('git.showCommit', async () => {
     await manager.showCommit()
   }))

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -8,6 +8,7 @@ import Repo from './repo'
 import Resolver from './resolver'
 import { ChangeType, Diff, SignInfo } from './types'
 import { equals, getUrl, spawnCommand } from './util'
+import { Range } from 'vscode-languageserver-protocol'
 
 interface FoldSettings {
   foldmethod: string
@@ -336,6 +337,17 @@ export default class DocumentManager {
       }
       return false
     })
+  }
+
+  public async chunkSelect(): Promise<void> {
+    let bufnr = await this.nvim.eval('bufnr("%")') as number
+    let doc = workspace.getDocument(bufnr)
+    if (!doc) return
+    let diff = await this.getCurrentChunk()
+    if (!diff) return
+    let endLine = doc.getline(diff.end - 1)
+    let range = Range.create(diff.start - 1, 0, diff.end - 1, endLine.length)
+    if (range) await workspace.selectRange(range)
   }
 
   public async showDoc(content: string, filetype = 'diff'): Promise<void> {


### PR DESCRIPTION
Attempt to fix #53 

It seems that opending-mode is not possible here since function is called asynchronously. So I added `git.chunkSelect` command only for visual selecting. 

Users can define keymappings like
```vim
vmap <silent> ih  :<C-U>CocCommand git.chunkSelect<CR>
```
or
```vim
nmap <silent> somekey  :<C-U>CocCommand git.chunkSelect<CR>
```

Close this PR if there are better solutions.