### PR TITLE
Update all buffers when COMMIT_EDITMSG is written

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   events.on('BufWritePost', bufnr => {
     let doc = workspace.getDocument(bufnr)
-    if (doc.uri.startsWith('fugitive:')) {
+    if (doc.uri.startsWith('fugitive:') || doc.uri.endsWith("COMMIT_EDITMSG")) {
       updateAll()
     }
   }, null, subscriptions)


### PR DESCRIPTION
The fix you made in #57 only partially fixed my problem.

This PR ensures that gutters are updated once COMMIT_EDITMSG is written by fugitive