### PR TITLE
Add issue formatting option for autocompletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
           "default": "origin",
           "description": "Remote name for fetch github issues."
         },
+        "git.issueFormat": {
+            "type": "string",
+            "default": "#%i",
+            "description": "Formatting string for issue completion. Supported interpolation variables: %i - issue id. %r - repository name. %o - organization/owner name. %t - issue title. %b - issue body. %c - issue created at. %a - issue author. %u - issue url."
+        },
         "git.virtualTextPrefix": {
           "type": "string",
           "default": "     ",


### PR DESCRIPTION
This adds a basic issue formatting option for autocompletion. This lets
users specify a formatting string in coc-config.json that will be used
to generate the text that will be inserted when accepting the
autocomplete suggestion while writing a commit message. The default
setting preserves the original behavior. (Additionally, this commit adds
the issue body to the preview window, because why not?).

As an example of how this feature can be used, the following was written
using the formatting string `This fixes %o/%r#%i - \"%t\".`:

This fixes neoclide/coc-git#61 - "Customizable formatting for issue
autocompletion".

<pre align=center><img alt src="https://user-images.githubusercontent.com/578029/66255001-98628600-e77e-11e9-8cac-5ced85810361.png"></pre>

