### PR TITLE
fix typo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,8 +59,8 @@ In your vim/neovim, run command:
 - `git.changeRemovedSign.text`:Text of change removed sign., default: `"≃"`.
 - `git.changeRemovedSign.hlGroup`:Highlight group for change removed sign., default: `"DiffDelete"`.
 - `git.virtualTextPrefix`:Prefix of git blame information to virtual text, require virtual text feature of neovim. default: `5 <Space>`.
-- `git.addGlameToVirtualText`:Add git blame information to virtual text, require virtual text feature of neovim. default: `false`.
-- `git.addGlameToBufferVar`:Add git blame information to b:coc_git_blame. default: `false`.
+- `git.addGBlameToVirtualText`:Add git blame information to virtual text, require virtual text feature of neovim. default: `false`.
+- `git.addGBlameToBufferVar`:Add git blame information to b:coc_git_blame. default: `false`.
 - `git.semanticCommit.filetypes` filetype list to enable semantic commit completion, default: `["gitcommit", "gina-commit"]`
 - `git.gitlab.hosts`: Custom GitLab host list, defaults: `['gitlab.com']`
 - `coc.source.issues.enable` enable issues completion from github, default `true`.

--- a/Readme.md
+++ b/Readme.md
@@ -41,32 +41,32 @@ In your vim/neovim, run command:
 
 ## Configuration
 
-- `git.enableGlobalStatus`:Enable global g:coc_git_status, default: `true`.
-- `git.command`:Command for git, could be absolute path of git executable, default: `"git"`.
-- `git.branchCharacter`:Branch character used with g:coc_git_branch, default: `""`.
+- `git.enableGlobalStatus`: Enable global g:coc_git_status, default: `true`.
+- `git.command`: Command for git, could be absolute path of git executable, default: `"git"`.
+- `git.branchCharacter`: Branch character used with g:coc_git_branch, default: `""`.
 - `git.remoteName`: Remote name used for fetch github issues, default: `origin`.
-- `git.enableGutters`:Enable gutters in sign column., default: `true`.
-- `git.realtimeGutters`:Change to `false` when you want gutters update only on save, default: `true`.
-- `git.signOffset`:Start offset of sign gutter, change to higher value to prevent overwrite by other plugin., default: `99`.
-- `git.changedSign.text`:Text of changed sign., default: `"~"`.
-- `git.changedSign.hlGroup`:Highlight group for changed sign., default: `"DiffChange"`.
-- `git.addedSign.text`:Text of added sign., default: `"+"`.
-- `git.addedSign.hlGroup`:Highlight group for added sign., default: `"DiffAdd"`.
-- `git.removedSign.text`:Text of removed sign., default: `"_"`.
-- `git.removedSign.hlGroup`:Highlight group for removed sign., default: `"DiffDelete"`.
-- `git.topRemovedSign.text`:Text of top removed sign., default: `"‾"`.
-- `git.topRemovedSign.hlGroup`:Highlight group for top removed sign., default: `"DiffDelete"`.
-- `git.changeRemovedSign.text`:Text of change removed sign., default: `"≃"`.
-- `git.changeRemovedSign.hlGroup`:Highlight group for change removed sign., default: `"DiffDelete"`.
-- `git.virtualTextPrefix`:Prefix of git blame information to virtual text, require virtual text feature of neovim. default: `5 <Space>`.
-- `git.addGBlameToVirtualText`:Add git blame information to virtual text, require virtual text feature of neovim. default: `false`.
-- `git.addGBlameToBufferVar`:Add git blame information to b:coc_git_blame. default: `false`.
-- `git.semanticCommit.filetypes` filetype list to enable semantic commit completion, default: `["gitcommit", "gina-commit"]`
+- `git.enableGutters`: Enable gutters in sign column., default: `true`.
+- `git.realtimeGutters`: Change to `false` when you want gutters update only on save, default: `true`.
+- `git.signOffset`: Start offset of sign gutter, change to higher value to prevent overwrite by other plugin., default: `99`.
+- `git.changedSign.text`: Text of changed sign., default: `"~"`.
+- `git.changedSign.hlGroup`: Highlight group for changed sign., default: `"DiffChange"`.
+- `git.addedSign.text`: Text of added sign., default: `"+"`.
+- `git.addedSign.hlGroup`: Highlight group for added sign., default: `"DiffAdd"`.
+- `git.removedSign.text`: Text of removed sign., default: `"_"`.
+- `git.removedSign.hlGroup`: Highlight group for removed sign., default: `"DiffDelete"`.
+- `git.topRemovedSign.text`: Text of top removed sign., default: `"‾"`.
+- `git.topRemovedSign.hlGroup`: Highlight group for top removed sign., default: `"DiffDelete"`.
+- `git.changeRemovedSign.text`: Text of change removed sign., default: `"≃"`.
+- `git.changeRemovedSign.hlGroup`: Highlight group for change removed sign., default: `"DiffDelete"`.
+- `git.virtualTextPrefix`: Prefix of git blame information to virtual text, require virtual text feature of neovim. default: `5 <Space>`.
+- `git.addGBlameToVirtualText`: Add git blame information to virtual text, require virtual text feature of neovim. default: `false`.
+- `git.addGBlameToBufferVar`: Add git blame information to b:coc_git_blame. default: `false`.
+- `git.semanticCommit.filetypes`: filetype list to enable semantic commit completion, default: `["gitcommit", "gina-commit"]`
 - `git.gitlab.hosts`: Custom GitLab host list, defaults: `['gitlab.com']`
-- `coc.source.issues.enable` enable issues completion from github, default `true`.
-- `coc.source.issues.priority` priority of issues source, default: `9`.
-- `coc.source.issues.shortcut` shortcut of issues source, default: `"I"`.
-- `coc.source.issues.filetypes` filetype list to enable issues source, default: `["gitcommit", "gina-commit"]`
+- `coc.source.issues.enable`: enable issues completion from github, default `true`.
+- `coc.source.issues.priority`: priority of issues source, default: `9`.
+- `coc.source.issues.shortcut`: shortcut of issues source, default: `"I"`.
+- `coc.source.issues.filetypes`: filetype list to enable issues source, default: `["gitcommit", "gina-commit"]`
 
 more information, see [package.json](https://github.com/neoclide/coc-git/blob/master/package.json)
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,16 @@
           "default": "     ",
           "description": "Prefix of git blame infomation to virtual text, require virtual text feature of neovim."
         },
+        "git.addGlameToVirtualText": {
+          "type": "boolean",
+          "default": false,
+          "description": "Deprecated: Add git blame information to virtual text, require virtual text feature of neovim."
+        },
+        "git.addGlameToBufferVar": {
+          "type": "boolean",
+          "default": false,
+          "description": "Deprecated: Add git blame information to b:coc_git_blame."
+        },
         "git.addGBlameToVirtualText": {
           "type": "boolean",
           "default": false,

--- a/package.json
+++ b/package.json
@@ -85,12 +85,12 @@
           "default": "     ",
           "description": "Prefix of git blame infomation to virtual text, require virtual text feature of neovim."
         },
-        "git.addGlameToVirtualText": {
+        "git.addGBlameToVirtualText": {
           "type": "boolean",
           "default": false,
           "description": "Add git blame information to virtual text, require virtual text feature of neovim."
         },
-        "git.addGlameToBufferVar": {
+        "git.addGBlameToBufferVar": {
           "type": "boolean",
           "default": false,
           "description": "Add git blame information to b:coc_git_blame."

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -81,9 +81,19 @@ export default class DocumentManager {
     }, null, this.disposables)
   }
 
+  private getConfig<T>(key: string, defaultValue: T, deprecatedKey?: string): T {
+    if (deprecatedKey) {
+      let inspectDeprecated = this.config.inspect(deprecatedKey)
+      if (inspectDeprecated.globalValue != null || inspectDeprecated.workspaceValue != null) {
+        workspace.showMessage(`"${deprecatedKey}" is deprecated in favor of "${key}", please update your config file (:CocConfig)`, 'warning')
+      }
+    }
+    return this.config.get<T>(key, defaultValue)
+  }
+
   private get showBlame(): boolean {
-    let blame = this.config.get<boolean>('addGBlameToVirtualText', false)
-    let blameVar = this.config.get<boolean>('addGBlameToBufferVar', false)
+    let blame = this.getConfig<boolean>('addGBlameToVirtualText', false, 'addGlameToVirtualText')
+    let blameVar = this.getConfig<boolean>('addGBlameToBufferVar', false, 'addGlameToBufferVar')
     return blame || blameVar
   }
 
@@ -112,7 +122,7 @@ export default class DocumentManager {
         blameText = `(${blameInfo.author} ${blameInfo.time}) ${blameInfo.summary}`
       }
     }
-    if (this.config.get<boolean>('addGBlameToBufferVar', false)) {
+    if (this.getConfig<boolean>('addGBlameToBufferVar', false, 'addGlameToBufferVar')) {
       nvim.pauseNotification()
       doc.buffer.setVar('coc_git_blame', blameText, true)
       nvim.command('redraws', true)
@@ -134,7 +144,7 @@ export default class DocumentManager {
   }
 
   private get virtualText(): boolean {
-    return this.config.get<boolean>('addGBlameToVirtualText', false) && workspace.isNvim
+    return this.getConfig<boolean>('addGBlameToVirtualText', false, 'addGlameToVirtualText') && workspace.isNvim
   }
 
   private get signOffset(): number {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -82,8 +82,8 @@ export default class DocumentManager {
   }
 
   private get showBlame(): boolean {
-    let blame = this.config.get<boolean>('addGlameToVirtualText', false)
-    let blameVar = this.config.get<boolean>('addGlameToBufferVar', false)
+    let blame = this.config.get<boolean>('addGBlameToVirtualText', false)
+    let blameVar = this.config.get<boolean>('addGBlameToBufferVar', false)
     return blame || blameVar
   }
 
@@ -112,7 +112,7 @@ export default class DocumentManager {
         blameText = `(${blameInfo.author} ${blameInfo.time}) ${blameInfo.summary}`
       }
     }
-    if (this.config.get<boolean>('addGlameToBufferVar', false)) {
+    if (this.config.get<boolean>('addGBlameToBufferVar', false)) {
       nvim.pauseNotification()
       doc.buffer.setVar('coc_git_blame', blameText, true)
       nvim.command('redraws', true)
@@ -134,7 +134,7 @@ export default class DocumentManager {
   }
 
   private get virtualText(): boolean {
-    return this.config.get<boolean>('addGlameToVirtualText', false) && workspace.isNvim
+    return this.config.get<boolean>('addGBlameToVirtualText', false) && workspace.isNvim
   }
 
   private get signOffset(): number {


### PR DESCRIPTION
fix #66 

- `git.addGlameToVirtualText` -> `git.addGBlameToVirtualText`
- `git.addGlameToBufferVar` -> `git.addGBlameToBufferVar`
- show warning if the deprecated key is set
- add spaces after `:`s in README, to allow selecting config keys by double click