### PR TITLE
fix: Fix ChunkStage error when there are chunk before the current chunk

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -431,10 +431,10 @@ export default class DocumentManager {
         let { start, end } = diff
         for (let i = start; i <= end; i++) {
           let topdelete = diff.changeType == ChangeType.Delete && i == 0
-          let bottomdelete = diff.changeType == ChangeType.Change && diff.removed.count > diff.added.count && i == end
+          let changedelete = diff.changeType == ChangeType.Change && diff.removed.count > diff.added.count && i == end
           signs.push({
             signId,
-            changeType: topdelete ? 'topdelete' : bottomdelete ? 'bottomdelete' : diff.changeType,
+            changeType: topdelete ? 'topdelete' : changedelete ? 'changedelete' : diff.changeType,
             lnum: topdelete ? 1 : i
           })
           signId = signId + 1
@@ -491,7 +491,7 @@ export default class DocumentManager {
         return 'CocGitChanged'
       case 'topdelete':
         return 'CocGitTopRemoved'
-      case 'bottomdelete':
+      case 'changedelete':
         return 'CocGitChangeRemoved'
     }
     return ''

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -162,41 +162,51 @@ export function parseDiff(diffStr: string): Diff[] {
       .split(/\s+/)
       .map(str => str.slice(1).split(','))
 
-    const deleteCount = parseInt(`${pres[1] || 1}`, 10)
-    const addCount = parseInt(`${nows[1] || 1}`, 10)
-    const lineNum = parseInt(nows[0], 10)
+    const removed = {
+      start: parseInt(pres[0], 10),
+      count: parseInt(`${pres[1] || 1}`, 10)
+    }
+    const added = {
+      start: parseInt(nows[0], 10),
+      count: parseInt(`${nows[1] || 1}`, 10)
+    }
 
-    // delete
-    if (nows[1] === '0') {
+    if (added.count === 0) {
+      // delete
       diff = {
         lines: [],
+        start: added.start,
+        end: added.start,
         head: line,
-        start: lineNum,
-        end: lineNum,
+        removed,
+        added,
         changeType: ChangeType.Delete
       }
       diffs.push(diff)
-    } else {
-      if (deleteCount == 0) {
-        diff = {
-          lines: [],
-          head: line,
-          start: lineNum,
-          end: lineNum + addCount - 1,
-          changeType: ChangeType.Add
-        }
-        diffs.push(diff)
-      } else {
-        diff = {
-          lines: [],
-          head: line,
-          start: lineNum,
-          end: lineNum + Math.min(addCount, deleteCount) - 1,
-          delta: [addCount, deleteCount],
-          changeType: ChangeType.Change
-        }
-        diffs.push(diff)
+    } else if (removed.count === 0) {
+      // add
+      diff = {
+        lines: [],
+        start: added.start,
+        end: added.start + added.count - 1,
+        head: line,
+        removed,
+        added,
+        changeType: ChangeType.Add
       }
+      diffs.push(diff)
+    } else {
+      // change
+      diff = {
+        lines: [],
+        start: added.start,
+        end: added.start + Math.min(added.count, removed.count) - 1,
+        head: line,
+        removed,
+        added,
+        changeType: ChangeType.Change
+      }
+      diffs.push(diff)
     }
   }
   return diffs

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,9 +10,15 @@ export interface Diff {
   start: number
   end: number
   head: string
+  removed: {
+    start: number
+    count: number
+  }
+  added: {
+    start: number
+    count: number
+  }
   lines: string[]
-  // removed count and added count
-  delta?: [number, number]
 }
 
 export interface SignInfo {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,6 @@ export interface Diff {
 
 export interface SignInfo {
   lnum: number
-  changeType: ChangeType | 'topdelete' | 'bottomdelete'
+  changeType: ChangeType | 'topdelete' | 'changedelete'
   signId: number
 }


### PR DESCRIPTION
### How to reproduce

```diff
  1 
  2 
¯ 4 
  5 
+ aaa <cursor>
+ aaa
  6 
  7 
  8 
  9 
  10
```

execute `:CocCommand git.chunkStage`

```diff
  1 
  2 
¯ 4 
+ 5 
  aaa <cursor>
_ aaa
  6 
  7 
  8 
  9 
  10
```