### PR TITLE
fix: fix git show command on Windows 10

### DIFF
--- a/src/repo.ts
+++ b/src/repo.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import util from 'util'
 import Git, {IExecutionResult, SpawnOptions} from './git'
 import {ChangeType, Diff} from './types'
-import {getStdout, shellescape} from './util'
+import {getStdout, shellescape, toUnixSlash} from './util'
 import uuid = require('uuid/v4')
 
 interface Decorator {
@@ -116,7 +116,7 @@ export default class Repo {
     try {
       let res = await this.exec(['ls-files', '--', file])
       if (!res.stdout.trim().length) return
-      res = await this.exec(['--no-pager', 'show', `${revision}:${file}`])
+      res = await this.exec(['--no-pager', 'show', `${revision}:${toUnixSlash(file)}`])
       if (!res.stdout) return
       staged = res.stdout.replace(/\r?\n$/, '').split(/\r?\n/).join('\n')
     } catch (e) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -21,6 +21,10 @@ export function shellescape(s: string): string {
   return s
 }
 
+export function toUnixSlash(fsPath: string): string {
+  return fsPath.replace(/\\/, '/')
+}
+
 export async function safeRun(cmd: string, opts: ExecOptions = {}): Promise<string> {
   try {
     return await runCommand(cmd, opts, 5000)


### PR DESCRIPTION
The path of `\\` is not supported for `git show :$PATH` command on Windows