### PR TITLE
fix: add `g` flag to toUnixSlash regexp

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -22,7 +22,9 @@ export function shellescape(s: string): string {
 }
 
 export function toUnixSlash(fsPath: string): string {
-  return fsPath.replace(/\\/, '/')
+  if (process.platform == 'win32') {
+      return fsPath.replace(/\\/g, '/')
+  }
 }
 
 export async function safeRun(cmd: string, opts: ExecOptions = {}): Promise<string> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,8 +23,9 @@ export function shellescape(s: string): string {
 
 export function toUnixSlash(fsPath: string): string {
   if (process.platform == 'win32') {
-      return fsPath.replace(/\\/g, '/')
+    return fsPath.replace(/\\/g, '/')
   }
+  return fsPath
 }
 
 export async function safeRun(cmd: string, opts: ExecOptions = {}): Promise<string> {


### PR DESCRIPTION
Sorry for missing a `g` flag in the last patch