### PR TITLE
Added option to disable blame virtual text

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -140,6 +140,10 @@ export default class DocumentManager {
 
   private get showBlame(): boolean {
     if (!workspace.nvim.hasFunction('nvim_buf_set_virtual_text')) return false
+    const disableBlame = await workspace.nvim.getVar('coc_git_no_virtual_blame')
+    if (disableBlame) {
+      return false
+    }
     let blame = this.getConfig<boolean>('addGBlameToVirtualText', false, 'addGlameToVirtualText')
     let blameVar = this.getConfig<boolean>('addGBlameToBufferVar', false, 'addGlameToBufferVar')
     return blame || blameVar


### PR DESCRIPTION
Having this setting on globally is great, but in some buffers like
`gitcommit` files, or other types, you may want to disable this. This
change reads a variable per buffer so you can disable it in these cases.