### PR TITLE
Add go to next/prev conflict feature

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,7 @@ In your vim/neovim, run command:
 - Git related lists, including `issues`, `gfiles`, `gstatus`, `commits`, `branches` & `bcommits`
 - Keymaps for git chunks, including `<Plug>(coc-git-chunkinfo)` `<Plug>(coc-git-nextchunk)` & `<Plug>(coc-git-prevchunk)` ,
 - Commands for chunks, including `git.chunkInfo` `git.chunkStage` `git.chunkUndo` and more.
+- Keymaps for git conflicts, including `<Plug>(coc-git-nextconflict)` & `<Plug>(coc-git-prevconflict)`.
 - Completion support for semantic commit.
 - Completion support for GitHub/GitLab issues.
 
@@ -177,6 +178,9 @@ Create keymappings like:
 " navigate chunks of current buffer
 nmap [g <Plug>(coc-git-prevchunk)
 nmap ]g <Plug>(coc-git-nextchunk)
+" navigate conflicts of current buffer
+nmap [c <Plug>(coc-git-prevconflict)
+nmap ]c <Plug>(coc-git-nextconflict)
 " show chunk diff at current position
 nmap gs <Plug>(coc-git-chunkinfo)
 " show commit contains current position

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,14 @@ export async function activate(context: ExtensionContext): Promise<ExtensionApi 
     await manager.prevChunk()
   }, { sync: false }))
 
+  subscriptions.push(workspace.registerKeymap(['n'], 'git-nextconflict', async () => {
+    await manager.nextConflict()
+  }, { sync: false }))
+
+  subscriptions.push(workspace.registerKeymap(['n'], 'git-prevconflict', async () => {
+    await manager.prevConflict()
+  }, { sync: false }))
+
   subscriptions.push(workspace.registerKeymap(['n'], 'git-chunkinfo', async () => {
     await manager.chunkInfo()
   }, { sync: false }))

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,14 @@ export interface Diff {
   lines: string[]
 }
 
+export interface Conflict {
+  start: number
+  sep: number
+  end: number
+  their_rev: string
+  our_rev: string
+}
+
 export interface SignInfo {
   lnum: number
   changeType: ChangeType | 'topdelete' | 'changedelete'


### PR DESCRIPTION
Close #140. ~This PR makes the document manager maintain an array of all the conflicts of the current buffer, which is constructed by parsing the buffer looking for conflict markers~ (see edit below). Two actions `prevConflict` and `nextConflict` are added, which jump to the previous or the next conflict. Some additional info is kept on the conflict, such as the position of the various markers as well as the revisions: this is superfluous for this PR, but it's cheap to store, and may be used later (from there, it is easy to implement an action to say "keep my version" or "keep their version" of the current conflict under the cursor, for example).

I tested it on various files locally, using the channel to output debug info, and it seems to work as intended.

## Performance
[**EDIT**: changed since the beginning of this PR. All conflicts are not parsed and cached anymore. Rather, the next or previous conflict is searched on-demand from the current position]
~The file is parsed entirely to find these markers. I don't know if this is really worrysome (vim-airline [does the ~same](https://github.com/vim-airline/vim-airline/blob/44b7b729381738cef0fc28a35fbe78fc2abe4d48/autoload/airline/extensions/whitespace.vim#L51) in order to find conflict markers, and full line regexp are usually rather fast), but if it is, here are possible mitigations:~

- ~use a `git` call to determine which files have conflict, and disable conflict navigation (and thus the parsing step) for the others. The problem could be then that the git status is not in sync with the actual content of files for some reason.~
- ~do not cache any conflict, and only look for the previous one or the next one on-demand~