### PR TITLE
Conflicts: add highlighting and keepcurrent/keepincoming commands

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ In your vim/neovim, run command:
 - Git related lists, including `issues`, `gfiles`, `gstatus`, `commits`, `branches` & `bcommits`
 - Keymaps for git chunks, including `<Plug>(coc-git-chunkinfo)` `<Plug>(coc-git-nextchunk)` & `<Plug>(coc-git-prevchunk)` ,
 - Commands for chunks, including `git.chunkInfo` `git.chunkStage` `git.chunkUndo` and more.
-- Keymaps for git conflicts, including `<Plug>(coc-git-nextconflict)` & `<Plug>(coc-git-prevconflict)`.
+- Keymaps for git conflicts, including `<Plug>(coc-git-nextconflict)`, `<Plug>(coc-git-prevconflict)`, `<Plug>(coc-git-keepcurrent)` & `<Plug>(coc-git-keepincoming)`.
 - Completion support for semantic commit.
 - Completion support for GitHub/GitLab issues.
 

--- a/package.json
+++ b/package.json
@@ -255,6 +255,16 @@
           ],
           "description": "Custom GitLab hosts"
         },
+        "git.conflict.current.hlGroup": {
+          "type": "string",
+          "default": "DiffChange",
+          "description": "Highlight group for the current version of a merge conflict."
+        },
+        "git.conflict.incoming.hlGroup": {
+          "type": "string",
+          "default": "DiffChange",
+          "description": "Highlight group for the incoming version of a merge conflict."
+        },
         "coc.source.issues.enable": {
           "type": "boolean",
           "default": true

--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
         },
         "git.conflict.incoming.hlGroup": {
           "type": "string",
-          "default": "DiffChange",
+          "default": "DiffAdd",
           "description": "Highlight group for the incoming version of a merge conflict."
         },
         "coc.source.issues.enable": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,14 @@ export async function activate(context: ExtensionContext): Promise<ExtensionApi 
     await manager.prevConflict()
   }, { sync: false }))
 
+  subscriptions.push(workspace.registerKeymap(['n'], 'git-keepcurrent', async () => {
+    await manager.keepCurrent()
+  }, { sync: false }))
+
+  subscriptions.push(workspace.registerKeymap(['n'], 'git-keepincoming', async () => {
+    await manager.keepIncoming()
+  }, { sync: false }))
+
   subscriptions.push(workspace.registerKeymap(['n'], 'git-chunkinfo', async () => {
     await manager.chunkInfo()
   }, { sync: false }))

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -38,7 +38,6 @@ export default class DocumentManager {
   private repoMap: Map<string, Repo> = new Map()
   private cachedDiffs: Map<number, Diff[]> = new Map()
   private cachedConflicts: Map<number, Conflict[]> = new Map()
-  private highlightedConflicts: Map<number, number[]> = new Map()
   private conflictSrcId: number = 0
   private cachedSigns: Map<number, SignInfo[]> = new Map()
   private cachedChangeTick: Map<number, number> = new Map()
@@ -118,7 +117,6 @@ export default class DocumentManager {
       }
       this.cachedDiffs.delete(bufnr)
       this.cachedConflicts.delete(bufnr)
-      this.highlightedConflicts.delete(bufnr)
       this.cachedSigns.delete(bufnr)
       this.cachedChangeTick.delete(bufnr)
       this.currentSigns.delete(bufnr)

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,8 +25,8 @@ export interface Conflict {
   start: number
   sep: number
   end: number
-  their_rev: string
-  our_rev: string
+  current: string
+  incoming: string
 }
 
 export interface SignInfo {


### PR DESCRIPTION
Close #115. Parse the conflicts of the current buffer in a dedicated structure in order to highlight them. Also use this tructure to jump to next/previous conflict. Add commands `git-keepcurrent` and `git-keepincoming` to keep either the current version or the incoming version of the conflict currently under the cursor, if there is any.

![coc-git-confclits-highlighting](https://user-images.githubusercontent.com/6530104/102140346-64452380-3e5f-11eb-8a0b-d2bbeae031a5.png)
