### PR TITLE
Add a keepboth commands for conflicts

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ In your vim/neovim, run command:
 - Git related lists, including `issues`, `gfiles`, `gstatus`, `commits`, `branches` & `bcommits`
 - Keymaps for git chunks, including `<Plug>(coc-git-chunkinfo)` `<Plug>(coc-git-nextchunk)` & `<Plug>(coc-git-prevchunk)` ,
 - Commands for chunks, including `git.chunkInfo` `git.chunkStage` `git.chunkUndo` and more.
-- Keymaps for git conflicts, including `<Plug>(coc-git-nextconflict)`, `<Plug>(coc-git-prevconflict)`, `<Plug>(coc-git-keepcurrent)` & `<Plug>(coc-git-keepincoming)`.
+- Keymaps for git conflicts, including `<Plug>(coc-git-nextconflict)`, `<Plug>(coc-git-prevconflict)`, `<Plug>(coc-git-keepcurrent)`, `<Plug>(coc-git-keepincoming)` & `<Plug>(coc-git-keepboth)`.
 - Completion support for semantic commit.
 - Completion support for GitHub/GitLab issues.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,10 @@ export async function activate(context: ExtensionContext): Promise<ExtensionApi 
     await manager.keepIncoming()
   }, { sync: false }))
 
+  subscriptions.push(workspace.registerKeymap(['n'], 'git-keepboth', async () => {
+    await manager.keepBoth()
+  }, { sync: false }))
+
   subscriptions.push(workspace.registerKeymap(['n'], 'git-chunkinfo', async () => {
     await manager.chunkInfo()
   }, { sync: false }))

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -199,6 +199,10 @@ export default class DocumentManager {
     return this.conflictKeepPart(ConflictPart.Incoming)
   }
 
+  public async keepBoth(): Promise<void> {
+    return this.conflictKeepPart(ConflictPart.Both)
+  }
+
   private async conflictKeepPart(part: ConflictPart) {
     let buf = await this.buffer
     if (buf) await buf.conflictKeepPart(part)

--- a/src/model/buffer.ts
+++ b/src/model/buffer.ts
@@ -408,13 +408,17 @@ export default class GitBuffer implements Disposable {
     let line = await nvim.call('line', '.')
     for (let conflict of conflicts) {
       if (conflict.start <= line && conflict.end >= line) {
-        if (part == ConflictPart.Current) {
-          await nvim.command(`${conflict.start}d`)
-          return nvim.command(`${conflict.sep - 1},${conflict.end - 1}d`)
-        }
-        else {
-          await nvim.command(`${conflict.start},${conflict.sep}d`)
-          return nvim.command(`${conflict.end - (conflict.sep - conflict.start + 1)}d`)
+        switch(part) {
+          case ConflictPart.Current:
+            await nvim.command(`${conflict.sep},${conflict.end}d`)
+            return nvim.command(`${conflict.start}d`)
+          case ConflictPart.Incoming:
+            await nvim.command(`${conflict.end}d`)
+            return nvim.command(`${conflict.start},${conflict.sep}d`)
+          case ConflictPart.Both:
+            await nvim.command(`${conflict.end}d`)
+            await nvim.command(`${conflict.sep}d`)
+            return nvim.command(`${conflict.start}d`)
         }
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,5 +109,6 @@ export enum ConflictParseState {
 export enum ConflictPart {
   Current,
   Incoming,
+  Both,
 }
 


### PR DESCRIPTION
There are `git-keepincoming` and `git-keepcurrent` commands to keep either the current version or the incoming change in case of conflict. This PR adds a third `git-keepboth` command, when one desires to keep both part of a conflict.