### PR TITLE
Add support to hide temporary the blame virtual text

### DIFF
--- a/src/model/buffer.ts
+++ b/src/model/buffer.ts
@@ -172,7 +172,6 @@ export default class GitBuffer implements Disposable {
   public async showBlameInfo(lnum: number): Promise<void> {
     let { nvim } = workspace
     let { virtualTextSrcId } = this.config
-    let hide_blame = nvim.getVar( "coc_git_hide_blame_virtual_text" )
     if (!this.showBlame) return
     let infos = this.blameInfo
     if (!infos) return
@@ -188,6 +187,7 @@ export default class GitBuffer implements Disposable {
       }
     }
     let buffer = nvim.createBuffer(this.doc.bufnr)
+    let hide_blame = await nvim.getVar( "coc_git_hide_blame_virtual_text" )
     if (hide_blame) {
       const prefix = this.config.virtualTextPrefix
       await buffer.request('nvim_buf_clear_namespace', [virtualTextSrcId, 0, -1])


### PR DESCRIPTION
This feature allows the user to set a nvim global variable to hide temporary the virtual text for the git blame.

I was using the virtual text for the blame information, but the issues is that, when working on some code (i.e. changed but not commited yet) that contains an error, the linter will also try to show the error with virtual text, and the "not committed yet" and the error are overlapping.
Since the "not committed yet" is less important that the error mesage from the linter (also because I have this information in the gutter), it could be interessting to allow the user to have a toggle, from within vim and without changing the cocconfiguration, to hide temporary the git blame information.

What do you think ?
Thanks