### PR TITLE
feat: try to make copyUrl work with gitea, gerrit and gitlab

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -63,6 +63,8 @@ In your vim/neovim, run command:
 
 - `git.urlMode`: URL mode for browserOpen and copyUrl, you can set it to `"permalink"`. default: `"normal"`
 
+- `git.urlFix`: a object to configure the url style of copyUrl and browserOpen, make this two command support other git services like gitlab and gitea. default: `{}`
+
 - `git.issueFormat`: Formatting string for issue completion. Supported interpolation variables: %i - issue id. %r - repository name. %o - organization/owner name. %t - issue title. %b - issue body. %c - issue created at. %a - issue author. %u - issue url., default: `"#%i"`
 
 - `git.virtualTextPrefix`: Prefix of git blame infomation to virtual text, require virtual text feature of neovim., default: `" "`

--- a/package.json
+++ b/package.json
@@ -99,6 +99,28 @@
             "permalink"
           ]
         },
+        "git.urlFix": {
+          "type": "object",
+          "default": {},
+          "examples": [
+            {
+              "gitlab.org": [
+                "blob|-/blob",
+                "blob|-/blob"
+              ],
+              "gitea.com": [
+                "blob|src/branch",
+                "blob|src/commit"
+              ],
+              "gerrit.with.gitiles": [
+                "(.*)\/a\/(.*)\/blob\/(.*)#L(.*)|$1/plugins/gitiles/$2/+/refs/heads/$3#$4",
+                "(.*)\/a\/(.*)\/blob\/(.*)#L(.*)|$1/plugins/gitiles/$2/+/$3#$4"
+              ]
+            }
+          ],
+          "format": "{\"git-service-1's domain\":[\"fix-for-normal-url\",\"fix-for-permalink\"],\"git-service-2's domain\":...}",
+          "description": "A fix is a string, like \"pattern|replacement\" show in examples sessions, use to transform github style url to whatever you like. copyUrl will run url.replace(pattern,replacement) after generate a github style url. Example configuration make browserOpen and copyUrl work with gitlab, gitea and gerrit with gitiles."
+        },
         "git.diffRevision": {
           "type": "string",
           "default": "",

--- a/src/util.ts
+++ b/src/util.ts
@@ -163,21 +163,27 @@ export function equals(one: any, other: any): boolean {
   return true
 }
 
-export function getUrl(remote: string, branch: string, filepath: string, lines?: number[] | string): string {
-  let uri = remote.replace(/\.git$/, '')
-  if (uri.startsWith('git@')) {
-    let str = uri.slice(4)
+export function getRepoUrl(remote: string): string {
+  let url = remote.replace(/\s+$/, '').replace(/\.git$/, '')
+  if (url.startsWith('git@')) {
+    let str = url.slice(4)
     let parts = str.split(':', 2)
-    uri = `https://${parts[0]}/${parts[1]}`
+    url = `https://${parts[0]}/${parts[1]}`
   }
-  // let { hostname } = parse(uri)
+  return url
+}
+
+export function getUrl(fix: string, repoURL: string, name: string, filepath: string, lines?: number[] | string): string {
   let anchor = ''
   if (lines && Array.isArray(lines)) {
     anchor = lines ? lines.map(l => `L${l}`).join('-') : ''
   } else if (typeof lines == 'string') {
     anchor = lines
   }
-  return uri + '/blob/' + branch + '/' + filepath + (anchor ? '#' + anchor : '')
+  let url = repoURL + '/blob/' + name + '/' + filepath + (anchor ? '#' + anchor : '')
+  let parts = fix.split('|')
+  let match = RegExp(parts[0]), result = parts[1]
+  return url.replace(match, result)
 }
 
 function parseVersion(raw: string): string {


### PR DESCRIPTION
Add a new configuration item that make browserOpen and copyUrl works with other git services like gitlab, gitea and gerrit. 
just run a custom replace after generate github style url.

