### PR TITLE
Pass `--no-ext-diff` to `git diff`

### DIFF
--- a/src/lists/commits.ts
+++ b/src/lists/commits.ts
@@ -143,7 +143,7 @@ export default class Commits extends BasicList {
       } else {
         arg = `${list[1].data.commit} ${list[0].data.commit}`
       }
-      let content = await runCommand(`git --no-pager diff ${arg}`, { cwd: list[0].data.root })
+      let content = await runCommand(`git --no-pager diff --no-ext-diff ${arg}`, { cwd: list[0].data.root })
       let lines = content.replace(/\n$/, '').split('\n')
       nvim.pauseNotification()
       nvim.command(`tabe [diff ${arg}]`, true)
@@ -167,7 +167,7 @@ export default class Commits extends BasicList {
       } else {
         arg = `${list[1].data.commit} ${list[0].data.commit}`
       }
-      let content = await runCommand(`git --no-pager diff ${arg}`, { cwd: list[0].data.root })
+      let content = await runCommand(`git --no-pager diff --no-ext-diff ${arg}`, { cwd: list[0].data.root })
       let lines = content.replace(/\n$/, '').split('\n')
       let winid = context.listWindow.id
       let mod = context.options.position == 'tab' ? 'below' : 'above'

--- a/src/lists/gfiles.ts
+++ b/src/lists/gfiles.ts
@@ -43,7 +43,7 @@ export default class Gfiles extends BasicList {
     this.addAction('preview', async (item, context) => {
       let { root, sha, filepath, branch } = item.data
       if (!sha) return
-      let content = await runCommand(`git --no-pager diff ${branch} -- ${shellescape(filepath)}`, { cwd: root })
+      let content = await runCommand(`git --no-pager diff --no-ext-diff ${branch} -- ${shellescape(filepath)}`, { cwd: root })
       let lines = content.replace(/\n$/, '').split('\n')
       await this.preview({
         lines,

--- a/src/lists/gstatus.ts
+++ b/src/lists/gstatus.ts
@@ -94,7 +94,7 @@ export default class GStatus extends BasicList {
         }, context)
         return
       }
-      let args = ['--no-pager', 'diff']
+      let args = ['--no-pager', 'diff', '--no-ext-diff']
       if (index_symbol == 'M' && tree_symbol != 'M') {
         args.push('--cached')
       }

--- a/src/model/repo.ts
+++ b/src/model/repo.ts
@@ -21,7 +21,7 @@ export default class Repo {
    * Get staged info
    */
   public async getStagedChunks(relpath?: string): Promise<DiffChunks> {
-    let args = ['--no-pager', 'diff', '-p', '-U0', '--no-color', '--staged']
+    let args = ['--no-pager', 'diff', '--no-ext-diff', '-p', '-U0', '--no-color', '--staged']
     if (relpath) args.push(toUnixSlash(relpath))
     const result = await this.exec(args)
     if (!result.stdout) {
@@ -163,7 +163,7 @@ export default class Repo {
     const currentFile = path.join(os.tmpdir(), `coc-${uuid()}`)
     await util.promisify(fs.writeFile)(stagedFile, staged + '\n', 'utf8')
     await util.promisify(fs.writeFile)(currentFile, content, 'utf8')
-    let output = await getStdout(`git --no-pager diff -p -U0 --no-color ${shellescape(stagedFile)} ${shellescape(currentFile)}`)
+    let output = await getStdout(`git --no-pager diff --no-ext-diff -p -U0 --no-color ${shellescape(stagedFile)} ${shellescape(currentFile)}`)
     await util.promisify(fs.unlink)(stagedFile)
     await util.promisify(fs.unlink)(currentFile)
     if (!output) return []


### PR DESCRIPTION
External diff commands can produce output that is not handled by
coc-git.

Fixes https://github.com/neoclide/coc-git/issues/194

----

This is untested as I have no idea how to compile and run a local version :) The commands themselves are working fine though so I expect it to work.