### PR TITLE
Add showBlameDoc command and gchunks list

### DIFF
--- a/package.json
+++ b/package.json
@@ -312,6 +312,11 @@
           "default": "DiffAdd",
           "description": "Highlight group for the incoming version of a merge conflict."
         },
+        "git.gstatus.saveBeforeOpen": {
+          "type": "boolean",
+          "default": "false",
+          "description": "Auto save opened files before open list."
+        },
         "coc.source.issues.enable": {
           "type": "boolean",
           "default": true

--- a/package.json
+++ b/package.json
@@ -74,6 +74,10 @@
       {
         "title": "Push code of current branch to remote",
         "command": "git.push"
+      },
+      {
+        "title": "Show git blame info in float or popup window",
+        "command": "git.showBlameDoc"
       }
     ],
     "configuration": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,10 @@ export async function activate(context: ExtensionContext): Promise<ExtensionApi 
     await manager.showCommit()
   }, { sync: false }))
 
+  subscriptions.push(workspace.registerKeymap(['n'], 'git-showblamedoc', async () => {
+    await manager.showBlameDoc()
+  }, { sync: false }))
+
   subscriptions.push(commands.registerCommand('git.keepCurrent', async () => {
     await manager.keepCurrent()
   }))
@@ -135,6 +139,10 @@ export async function activate(context: ExtensionContext): Promise<ExtensionApi 
 
   subscriptions.push(commands.registerCommand('git.foldUnchanged', async () => {
     await manager.toggleFold()
+  }))
+
+  subscriptions.push(commands.registerCommand('git.showBlameDoc', async () => {
+    await manager.showBlameDoc()
   }))
 
   subscriptions.push(listManager.registerList(new GStatus(nvim, manager)))

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import Branches from './lists/branches'
 import Commits from './lists/commits'
 import Gfiles from './lists/gfiles'
 import GStatus from './lists/gstatus'
+import GChunks from './lists/gchunks'
 import Manager from './manager'
 import Git from './model/git'
 import Resolver from './model/resolver'
@@ -150,6 +151,7 @@ export async function activate(context: ExtensionContext): Promise<ExtensionApi 
   subscriptions.push(listManager.registerList(new Commits(nvim, manager)))
   subscriptions.push(listManager.registerList(new Bcommits(nvim, manager)))
   subscriptions.push(listManager.registerList(new Gfiles(nvim, manager)))
+  subscriptions.push(listManager.registerList(new GChunks(nvim, manager)))
   subscriptions.push(languages.registerCompletionItemProvider('semantic-commit', 'Commit', config.get<string[]>('semanticCommit.filetypes'), {
     provideCompletionItems: async (document, position): Promise<CompletionItem[]> => {
       if (position.line !== 0) {

--- a/src/lists/gchunks.ts
+++ b/src/lists/gchunks.ts
@@ -1,0 +1,71 @@
+import { BasicList, ListContext, ListItem, Neovim, window } from 'coc.nvim'
+import Manager from '../manager'
+import { StageChunk } from '../types'
+import colors from 'colors/safe'
+
+export default class GChunks extends BasicList {
+  public readonly name = 'gchunks'
+  public readonly description = 'Git changes of current buffer'
+  public readonly defaultAction = 'jump'
+
+  constructor(nvim: Neovim, private manager: Manager) {
+    super(nvim)
+    this.actions.push({
+      name: 'jump',
+      execute: item => {
+        if (Array.isArray(item)) return
+        window.moveTo({ line: Math.max(item.data.line - 1, 0), character: 0 })
+      }
+    })
+  }
+
+  public async loadItems(context: ListContext): Promise<ListItem[]> {
+    let buf = this.manager.getBuffer(context.buffer.id)
+    if (!buf) {
+      throw new Error(`Can't resolve git root.`)
+      return
+    }
+    let res: ListItem[] = []
+    let diffs = buf.cachedDiffs
+    if (diffs && diffs.length > 0) {
+      for (let diff of diffs) {
+        let stagedSign = ' '
+        res.push({
+          label: `${stagedSign} Line:${diff.start} ${diff.lines[0]}`,
+          sortText: `${diff.start}`,
+          data: {
+            line: diff.start
+          }
+        })
+      }
+    }
+    try { 
+      let { relpath } = buf
+      let stagedDiff = await buf.repo.getStagedChunks(relpath)
+      let chunks: StageChunk[] = Object.values(stagedDiff)[0]
+      if (chunks.length > 0) {
+        for (let diff of chunks) {
+          let adjust = 0
+          let stagedSign = colors.green('*')
+          let line = diff.add.lnum
+          for (let diff of diffs) {
+            if (diff.end >= line) {
+              break
+            }
+            adjust += diff.added.count
+            adjust -= diff.removed.count
+          }
+          line += adjust
+          res.push({
+            label: `${stagedSign} Line:${line} ${diff.lines[0]}`,
+            data: {
+              line: `${line}`
+            }
+          })
+        }
+      }
+    } catch (e) {
+    }
+    return res
+  }
+}

--- a/src/lists/gstatus.ts
+++ b/src/lists/gstatus.ts
@@ -125,6 +125,9 @@ export default class GStatus extends BasicList {
       throw new Error(`Can't resolve git root.`)
       return
     }
+    if (this.manager.gstatusSaveBeforeOpen) {
+     await this.nvim.command(`wa`)
+    }
     let output = await runCommand(`git status --porcelain -uall ${context.args.join(' ')}`, { cwd: root })
     output = output.replace(/\s+$/, '')
     if (!output) return []

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -126,6 +126,9 @@ export default class DocumentManager {
         currentHlGroup: config.get<string>('conflict.current.hlGroup', 'DiffChange'),
         incomingHlGroup: config.get<string>('conflict.incoming.hlGroup', 'DiffAdd')
       },
+      gstatus: {
+        saveBeforeOpen: config.get<boolean>('gstatus.saveBeforeOpen', false)
+      },
       virtualTextSrcId: this.virtualTextSrcId,
       conflictSrcId: this.conflictSrcId
     }
@@ -134,6 +137,10 @@ export default class DocumentManager {
 
   private get enableGutters(): boolean {
     return this.config.enableGutters
+  }
+
+  public get gstatusSaveBeforeOpen(): boolean {
+    return this.config.gstatus.saveBeforeOpen
   }
 
   public get git(): Git {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -240,6 +240,13 @@ export default class DocumentManager {
     if (buf) await buf.showCommit()
   }
 
+  public async showBlameDoc(): Promise<void> {
+    const { nvim } = this
+    let buf = await this.buffer
+    let line = await this.nvim.call('line', '.')
+    if (buf) await buf.showBlameDoc(line)
+  }
+
   public async browser(action = 'open', range?: [number, number], permalink = false): Promise<void> {
     let buf = await this.buffer
     if (buf) await buf.browser(action, range, permalink)

--- a/src/model/buffer.ts
+++ b/src/model/buffer.ts
@@ -256,6 +256,25 @@ export default class GitBuffer implements Disposable {
     }
   }
 
+  public async showBlameDoc(lnum: number): Promise<void> {
+    let infos = this.blameInfo
+    if (!infos) return
+    if (infos.length == 0) {
+      window.showMessage('File not indexed')
+    } else {
+      let info = infos.find(o => lnum >= o.startLnum && lnum <= o.endLnum)
+      if (info && info.author && info.author != 'Not Committed Yet') {
+        let blameText:string[] = []
+        blameText.push(`${info.author}, ${info.time}`)
+        blameText.push(`${info.summary}`)
+        blameText.push(`${info.sha.substring(0, 7)}`)
+        await this.showDoc(blameText.join('\n\n'), 'text')
+      } else {
+        window.showMessage('Not committed yet')
+      }
+    }
+  }
+
   private async diffDocument(force = false): Promise<void> {
     let { nvim } = workspace
     let revision = this.config.diffRevision

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,9 @@ export interface GitConfiguration {
   }
   virtualTextSrcId: number
   conflictSrcId: number
+  gstatus: {
+    saveBeforeOpen: boolean
+  }
 }
 
 export interface BlameInfo {


### PR DESCRIPTION
Add `git.showBlameDoc` command to show blame in float window.

Add `gchunks` list to show all chunks in buffer.

`git.chunkInfo` command shows staged chunk info if hunk had been staged.