### PR TITLE
Add git float config to readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -117,6 +117,8 @@ In your vim/neovim, run command:
 
 - `git.showCommitInFloating`: Show commit in floating or popup window, default: `false`
 
+- `git.floatConfig`: Configure style of float window/popup, extends from floatFactory.floatConfig
+
 - `git.gitlab.hosts`: Custom GitLab hosts, default: `["gitlab.com"]`
 
 - `git.conflict.enabled`: Enable highlight conflict lines, default: `true`


### PR DESCRIPTION
I search for float configuration instructions in readme, but I can't find it.

Until I found him in package.json.

Maybe someone has the same problem as me.

So I think it is more appropriate here.