### PR TITLE
Align the first item in branch list

### DIFF
--- a/src/lists/branches.ts
+++ b/src/lists/branches.ts
@@ -72,7 +72,7 @@ export default class Branches implements IList {
       return
     }
     let result = await this.manager.git.exec(root, ['branch', '--no-color', ...context.args])
-    let output = result.stdout.trim()
+    let output = result.stdout
     if (output == null) return
     output = output.replace(/\s+$/, '')
     for (let line of output.split(/\r?\n/)) {


### PR DESCRIPTION
Output of `git branch` has 2 leading space each line. `trim` remove the spaces of the first line and this item is then not aligned with others.