### PR TITLE
add gchanges list

### DIFF
--- a/package.json
+++ b/package.json
@@ -483,6 +483,7 @@
     "timeago.js": "^4.0.2",
     "typescript": "^4.5.4",
     "uuid": "^7.0.1",
+    "vscode-uri": "^2.1.2",
     "which": "^2.0.2"
   },
   "dependencies": {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import Commits from './lists/commits'
 import Gfiles from './lists/gfiles'
 import GStatus from './lists/gstatus'
 import GChunks from './lists/gchunks'
+import GChanges from './lists/gchanges'
 import Manager from './manager'
 import Git from './model/git'
 import Resolver from './model/resolver'
@@ -152,6 +153,7 @@ export async function activate(context: ExtensionContext): Promise<ExtensionApi 
   subscriptions.push(listManager.registerList(new Bcommits(nvim, manager)))
   subscriptions.push(listManager.registerList(new Gfiles(nvim, manager)))
   subscriptions.push(listManager.registerList(new GChunks(nvim, manager)))
+  subscriptions.push(listManager.registerList(new GChanges(nvim, manager)))
   subscriptions.push(languages.registerCompletionItemProvider('semantic-commit', 'Commit', config.get<string[]>('semanticCommit.filetypes'), {
     provideCompletionItems: async (document, position): Promise<CompletionItem[]> => {
       if (position.line !== 0) {

--- a/src/lists/gchanges.ts
+++ b/src/lists/gchanges.ts
@@ -1,0 +1,54 @@
+import { BasicList, ListContext, ListItem, Neovim, window, Location, Range } from 'coc.nvim'
+import { URI } from 'vscode-uri'
+import Manager from '../manager'
+import path from 'path'
+import colors from 'colors/safe'
+import { DiffCategory } from '../types'
+
+export default class GChanges extends BasicList {
+  public readonly name = 'gchanges'
+  public readonly description = 'Git changes of repository'
+  public readonly defaultAction = 'open'
+
+  constructor(nvim: Neovim, private manager: Manager) {
+    super(nvim)
+    this.addLocationActions()
+  }
+
+  public async loadItems(context: ListContext): Promise<ListItem[]> {
+    let buf = await context.window.buffer;
+    let root = await this.manager.resolveGitRootFromBufferOrCwd(buf.id);
+    if (!root) {
+      throw new Error(`Can't resolve git root.`);
+      return;
+    }
+    
+    let args = context.args;
+    let category = DiffCategory.All;
+    if (args.indexOf('--cached') !== -1) {
+      category = DiffCategory.Staged;
+    } else if (args.indexOf('--unstaged') !== -1) {
+      category = DiffCategory.Unstaged;
+    } else {
+      category = DiffCategory.All;
+    }
+    let res: ListItem[] = [];
+    let diffGropus = await this.manager.getDiffAll(category);
+    for (let [file, diffs] of diffGropus) {
+      for (let diff of diffs) {
+        let uri = URI.file(path.join(root, file)).toString();
+        let location = Location.create(
+          uri,
+          Range.create(diff.start - 1, 0, diff.end - 1, 0)
+        );
+        res.push({
+          label: `${colors.cyan(file)}:${colors.green(diff.start.toString())} ${diff.lines[0]}`,
+          sortText: `${file}:${diff.start}`,
+          data: { uri },
+          location,
+        });
+      }
+    }
+    return res;
+  }
+}

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -4,7 +4,7 @@ import GitBuffer from './model/buffer'
 import Git from './model/git'
 import Service from './model/service'
 import GitStatus from './model/status'
-import { ConflictPart, Diff, GitConfiguration } from './types'
+import { ConflictPart, Diff, DiffCategory, GitConfiguration } from './types'
 
 export default class DocumentManager {
   private buffers: Map<number, GitBuffer> = new Map()
@@ -310,6 +310,17 @@ export default class DocumentManager {
 
   public getBuffer(bufnr: number): GitBuffer | undefined {
     return this.buffers.get(bufnr)
+  }
+
+  public async getDiffAll(category: DiffCategory): Promise<Map<string, Diff[]>> {
+    let bufnr = await workspace.nvim.call('bufnr', '%')
+    let root = await this.resolveGitRootFromBufferOrCwd(bufnr)
+    if (!root) {
+      window.showMessage(`not belongs to git repository.`, 'warning')
+      return null
+    }
+    let repo = this.service.getRepoFromRoot(root)
+    return repo.getDiffAll(category)
   }
 
   public dispose(): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,12 @@ export interface Diff {
   lines: string[]
 }
 
+export enum DiffCategory {
+  All,
+  Staged,
+  Unstaged,
+}
+
 export interface Conflict {
   start: number
   sep: number


### PR DESCRIPTION
Add gchanges list to show all diffs of current repository. It calls `git diff HEAD` to get all diffs by default, and one can append args `--cached` or `--unstaged` to filter staged or unstaged changes.