### PR TITLE
fix `External file` matcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coc-git",
-  "version": "2.7.0",
+  "version": "2.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coc-git",
-      "version": "2.7.0",
+      "version": "2.7.2",
       "license": "MIT",
       "devDependencies": {
         "@chemzqm/tsconfig": "^0.0.3",

--- a/src/model/buffer.ts
+++ b/src/model/buffer.ts
@@ -418,7 +418,7 @@ export default class GitBuffer implements Disposable {
       let info: BlameInfo
       for (let line of r.stdout.trim().split(/\r?\n/)) {
         line = line.trim()
-        if (line.startsWith('External file (--contents)')) {
+        if (/^(author |committer )?External file \(--contents\)/.test(line)) {
           line = 'Not committed yet.'
         }
         let ms = line.match(/^([A-Za-z0-9]+)\s(\d+)\s(\d+)\s(\d+)/)


### PR DESCRIPTION
The blame line looks like `author External file (--contents)` or `committer External file (--contents)`, so we should allow leading `author` or `committer` to correctly replace it.