### PR TITLE
use shell for only Windows

### DIFF
--- a/src/model/git.ts
+++ b/src/model/git.ts
@@ -27,8 +27,8 @@ export default class Git {
   public async getRepositoryRoot(repositoryPath: string): Promise<string> {
     const result = await this.exec(repositoryPath, ['rev-parse', '--show-toplevel'])
     let repoRootPath = path.normalize(result.stdout.trim());
-    if (process.platform === 'win32' && repoRootPath .startsWith('\\') && !process.env.SHELL ) {
-        repoRootPath = repoRootPath.replace(/^\\([^\\]*)\\/, '$1:\\')
+    if (process.platform === 'win32' && repoRootPath.startsWith('\\') && !process.env.SHELL) {
+      repoRootPath = repoRootPath.replace(/^\\([^\\]*)\\/, '$1:\\')
     }
     return repoRootPath;
   }
@@ -88,7 +88,10 @@ export default class Git {
       LC_ALL: 'en_US.UTF-8',
       LANG: 'en_US.UTF-8'
     })
-    options.shell = options.env.SHELL ? options.env.SHELL : (process.platform === 'win32' || !!options.shell)
+
+    if (process.platform === 'win32') {
+      options.shell = true
+    }
 
     if (options.log !== false) {
       this.log(`> git ${args.join(' ')}\n`)


### PR DESCRIPTION
if process.env.SHELL is zsh, args need to be escaped

fixup e94b637b8aec6

```
const cp = require('child_process');
const git = cp.spawn('git', ['ls-files', '--', 'src/app/(normal)/token/[symbol]/layout.tsx'], {
    shell: process.env.SHELL,
});
git.stderr.on('data', (data) => {
    console.error('> error: ', data.toString());
});
git.stdout.on('data', (data) => {
    console.log('> data', data.toString());
});

```

If the shell is `zsh`
```
process.env.SHELL /bin/zsh
> error:  zsh:1: no matches found: src/app/(normal)/token/[symbol]/layout.tsx
```

Or we need to escape the `args`